### PR TITLE
Class-based layout

### DIFF
--- a/layout.html
+++ b/layout.html
@@ -1,6 +1,6 @@
 <!--
 @license
-Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
 This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
 The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
 The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
@@ -8,311 +8,312 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
 <style>
-/*******************************
-          Flex Layout
-*******************************/
 
-[layout][horizontal], [layout][vertical] {
-  display: -ms-flexbox;
-  display: -webkit-flex;
-  display: flex;
-}
+  /*******************************
+            Flex Layout
+  *******************************/
 
-[layout][horizontal][inline], [layout][vertical][inline] {
-  display: -ms-inline-flexbox;
-  display: -webkit-inline-flex;
-  display: inline-flex;
-}
+  [layout][horizontal], [layout][vertical] {
+    display: -ms-flexbox;
+    display: -webkit-flex;
+    display: flex;
+  }
 
-[layout][horizontal] {
-  -ms-flex-direction: row;
-  -webkit-flex-direction: row;
-  flex-direction: row;
-}
+  [layout][horizontal][inline], [layout][vertical][inline] {
+    display: -ms-inline-flexbox;
+    display: -webkit-inline-flex;
+    display: inline-flex;
+  }
 
-[layout][horizontal][reverse] {
-  -ms-flex-direction: row-reverse;
-  -webkit-flex-direction: row-reverse;
-  flex-direction: row-reverse;
-}
+  [layout][horizontal] {
+    -ms-flex-direction: row;
+    -webkit-flex-direction: row;
+    flex-direction: row;
+  }
 
-[layout][vertical] {
-  -ms-flex-direction: column;
-  -webkit-flex-direction: column;
-  flex-direction: column;
-}
+  [layout][horizontal][reverse] {
+    -ms-flex-direction: row-reverse;
+    -webkit-flex-direction: row-reverse;
+    flex-direction: row-reverse;
+  }
 
-[layout][vertical][reverse] {
-  -ms-flex-direction: column-reverse;
-  -webkit-flex-direction: column-reverse;
-  flex-direction: column-reverse;
-}
+  [layout][vertical] {
+    -ms-flex-direction: column;
+    -webkit-flex-direction: column;
+    flex-direction: column;
+  }
 
-[layout][wrap] {
-  -ms-flex-wrap: wrap;
-  -webkit-flex-wrap: wrap;
-  flex-wrap: wrap;
-}
+  [layout][vertical][reverse] {
+    -ms-flex-direction: column-reverse;
+    -webkit-flex-direction: column-reverse;
+    flex-direction: column-reverse;
+  }
 
-[layout][wrap-reverse] {
-  -ms-flex-wrap: wrap-reverse;
-  -webkit-flex-wrap: wrap-reverse;
-  flex-wrap: wrap-reverse;
-}
+  [layout][wrap] {
+    -ms-flex-wrap: wrap;
+    -webkit-flex-wrap: wrap;
+    flex-wrap: wrap;
+  }
 
-[flex] {
-  -ms-flex: 1;
-  -webkit-flex: 1;
-  flex: 1;
-}
+  [layout][wrap-reverse] {
+    -ms-flex-wrap: wrap-reverse;
+    -webkit-flex-wrap: wrap-reverse;
+    flex-wrap: wrap-reverse;
+  }
 
-[flex][auto] {
-  -ms-flex: 1 1 auto;
-  -webkit-flex: 1 1 auto;
-  flex: 1 1 auto;
-}
+  [flex] {
+    -ms-flex: 1;
+    -webkit-flex: 1;
+    flex: 1;
+  }
 
-[flex][none] {
-  -ms-flex: none;
-  -webkit-flex: none;
-  flex: none;
-}
+  [flex][auto] {
+    -ms-flex: 1 1 auto;
+    -webkit-flex: 1 1 auto;
+    flex: 1 1 auto;
+  }
 
-[flex][one] {
-  -ms-flex: 1;
-  -webkit-flex: 1;
-  flex: 1;
-}
+  [flex][none] {
+    -ms-flex: none;
+    -webkit-flex: none;
+    flex: none;
+  }
 
-[flex][two] {
-  -ms-flex: 2;
-  -webkit-flex: 2;
-  flex: 2;
-}
+  [flex][one] {
+    -ms-flex: 1;
+    -webkit-flex: 1;
+    flex: 1;
+  }
 
-[flex][three] {
-  -ms-flex: 3;
-  -webkit-flex: 3;
-  flex: 3;
-}
+  [flex][two] {
+    -ms-flex: 2;
+    -webkit-flex: 2;
+    flex: 2;
+  }
 
-[flex][four] {
-  -ms-flex: 4;
-  -webkit-flex: 4;
-  flex: 4;
-}
+  [flex][three] {
+    -ms-flex: 3;
+    -webkit-flex: 3;
+    flex: 3;
+  }
 
-[flex][five] {
-  -ms-flex: 5;
-  -webkit-flex: 5;
-  flex: 5;
-}
+  [flex][four] {
+    -ms-flex: 4;
+    -webkit-flex: 4;
+    flex: 4;
+  }
 
-[flex][six] {
-  -ms-flex: 6;
-  -webkit-flex: 6;
-  flex: 6;
-}
+  [flex][five] {
+    -ms-flex: 5;
+    -webkit-flex: 5;
+    flex: 5;
+  }
 
-[flex][seven] {
-  -ms-flex: 7;
-  -webkit-flex: 7;
-  flex: 7;
-}
+  [flex][six] {
+    -ms-flex: 6;
+    -webkit-flex: 6;
+    flex: 6;
+  }
 
-[flex][eight] {
-  -ms-flex: 8;
-  -webkit-flex: 8;
-  flex: 8;
-}
+  [flex][seven] {
+    -ms-flex: 7;
+    -webkit-flex: 7;
+    flex: 7;
+  }
 
-[flex][nine] {
-  -ms-flex: 9;
-  -webkit-flex: 9;
-  flex: 9;
-}
+  [flex][eight] {
+    -ms-flex: 8;
+    -webkit-flex: 8;
+    flex: 8;
+  }
 
-[flex][ten] {
-  -ms-flex: 10;
-  -webkit-flex: 10;
-  flex: 10;
-}
+  [flex][nine] {
+    -ms-flex: 9;
+    -webkit-flex: 9;
+    flex: 9;
+  }
 
-[flex][eleven] {
-  -ms-flex: 11;
-  -webkit-flex: 11;
-  flex: 11;
-}
+  [flex][ten] {
+    -ms-flex: 10;
+    -webkit-flex: 10;
+    flex: 10;
+  }
 
-[flex][twelve] {
-  -ms-flex: 12;
-  -webkit-flex: 12;
-  flex: 12;
-}
+  [flex][eleven] {
+    -ms-flex: 11;
+    -webkit-flex: 11;
+    flex: 11;
+  }
 
-/* alignment in cross axis */
+  [flex][twelve] {
+    -ms-flex: 12;
+    -webkit-flex: 12;
+    flex: 12;
+  }
 
-[layout][start] {
-  -ms-flex-align: start;
-  -webkit-align-items: flex-start;
-  align-items: flex-start;
-}
+  /* alignment in cross axis */
 
-[layout][center], [layout][center-center] {
-  -ms-flex-align: center;
-  -webkit-align-items: center;
-  align-items: center;
-}
+  [layout][start] {
+    -ms-flex-align: start;
+    -webkit-align-items: flex-start;
+    align-items: flex-start;
+  }
 
-[layout][end] {
-  -ms-flex-align: end;
-  -webkit-align-items: flex-end;
-  align-items: flex-end;
-}
+  [layout][center], [layout][center-center] {
+    -ms-flex-align: center;
+    -webkit-align-items: center;
+    align-items: center;
+  }
 
-/* alignment in main axis */
+  [layout][end] {
+    -ms-flex-align: end;
+    -webkit-align-items: flex-end;
+    align-items: flex-end;
+  }
 
-[layout][start-justified] {
-  -ms-flex-pack: start;
-  -webkit-justify-content: flex-start;
-  justify-content: flex-start;
-}
+  /* alignment in main axis */
 
-[layout][center-justified], [layout][center-center] {
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-}
+  [layout][start-justified] {
+    -ms-flex-pack: start;
+    -webkit-justify-content: flex-start;
+    justify-content: flex-start;
+  }
 
-[layout][end-justified] {
-  -ms-flex-pack: end;
-  -webkit-justify-content: flex-end;
-  justify-content: flex-end;
-}
+  [layout][center-justified], [layout][center-center] {
+    -ms-flex-pack: center;
+    -webkit-justify-content: center;
+    justify-content: center;
+  }
 
-[layout][around-justified] {
-  -ms-flex-pack: around;
-  -webkit-justify-content: space-around;
-  justify-content: space-around;
-}
+  [layout][end-justified] {
+    -ms-flex-pack: end;
+    -webkit-justify-content: flex-end;
+    justify-content: flex-end;
+  }
 
-[layout][justified] {
-  -ms-flex-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-}
+  [layout][around-justified] {
+    -ms-flex-pack: around;
+    -webkit-justify-content: space-around;
+    justify-content: space-around;
+  }
 
-/* self alignment */
+  [layout][justified] {
+    -ms-flex-pack: justify;
+    -webkit-justify-content: space-between;
+    justify-content: space-between;
+  }
 
-[self-start] {
-  -ms-align-self: flex-start;
-  -webkit-align-self: flex-start;
-  align-self: flex-start;
-}
+  /* self alignment */
 
-[self-center] {
-  -ms-align-self: center;
-  -webkit-align-self: center;
-  align-self: center;
-}
+  [self-start] {
+    -ms-align-self: flex-start;
+    -webkit-align-self: flex-start;
+    align-self: flex-start;
+  }
 
-[self-end] {
-  -ms-align-self: flex-end;
-  -webkit-align-self: flex-end;
-  align-self: flex-end;
-}
+  [self-center] {
+    -ms-align-self: center;
+    -webkit-align-self: center;
+    align-self: center;
+  }
 
-[self-stretch] {
-  -ms-align-self: stretch;
-  -webkit-align-self: stretch;
-  align-self: stretch;
-}
+  [self-end] {
+    -ms-align-self: flex-end;
+    -webkit-align-self: flex-end;
+    align-self: flex-end;
+  }
 
-/*******************************
-          Other Layout
-*******************************/
+  [self-stretch] {
+    -ms-align-self: stretch;
+    -webkit-align-self: stretch;
+    align-self: stretch;
+  }
 
-[block] {
-  display: block;
-}
+  /*******************************
+            Other Layout
+  *******************************/
 
-/* ie support for hidden */
-[hidden] {
-  display: none !important;
-}
+  [block] {
+    display: block;
+  }
 
-[invisible] {
-  visibility: hidden !important;
-}
+  /* ie support for hidden */
+  [hidden] {
+    display: none !important;
+  }
 
-[relative] {
-  position: relative;
-}
+  [invisible] {
+    visibility: hidden !important;
+  }
 
-[fit] {
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-}
+  [relative] {
+    position: relative;
+  }
 
-body[fullbleed] {
-  margin: 0;
-  height: 100vh;
-}
+  [fit] {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+  }
 
-[scroll] {
-  -webkit-overflow-scrolling: touch;
-  overflow: auto;
-}
+  body[fullbleed] {
+    margin: 0;
+    height: 100vh;
+  }
 
-/* fixed position */
+  [scroll] {
+    -webkit-overflow-scrolling: touch;
+    overflow: auto;
+  }
 
-[fixed-top] {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-}
+  /* fixed position */
 
-[fixed-right] {
-  position: fixed;
-  top: 0;
-  right: 0;
-  botttom: 0;
-}
+  [fixed-top] {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+  }
 
-[fixed-bottom] {
-  position: fixed;
-  right: 0;
-  bottom: 0;
-  left: 0;
-}
+  [fixed-right] {
+    position: fixed;
+    top: 0;
+    right: 0;
+    botttom: 0;
+  }
 
-[fixed-left] {
-  position: fixed;
-  top: 0;
-  botttom: 0;
-  left: 0;
-}
+  [fixed-bottom] {
+    position: fixed;
+    right: 0;
+    bottom: 0;
+    left: 0;
+  }
 
-/*******************************
-            Other
-*******************************/
+  [fixed-left] {
+    position: fixed;
+    top: 0;
+    botttom: 0;
+    left: 0;
+  }
 
-[segment], segment {
-  display: block;
-  position: relative;
-  -webkit-box-sizing: border-box;
-  -ms-box-sizing: border-box;
-  box-sizing: border-box;
-  margin: 1em 0.5em;
-  padding: 1em;
-  background-color: white;
-  -webkit-box-shadow: 0px 0px 0px 1px rgba(0, 0, 0, 0.1);
-  box-shadow: 0px 0px 0px 1px rgba(0, 0, 0, 0.1);
-  border-radius: 5px 5px 5px 5px;
-}
+  /*******************************
+              Other
+  *******************************/
+
+  [segment], segment {
+    display: block;
+    position: relative;
+    -webkit-box-sizing: border-box;
+    -ms-box-sizing: border-box;
+    box-sizing: border-box;
+    margin: 1em 0.5em;
+    padding: 1em;
+    background-color: white;
+    -webkit-box-shadow: 0px 0px 0px 1px rgba(0, 0, 0, 0.1);
+    box-shadow: 0px 0px 0px 1px rgba(0, 0, 0, 0.1);
+    border-radius: 5px 5px 5px 5px;
+  }
 
 </style>

--- a/layout.html
+++ b/layout.html
@@ -13,139 +13,137 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             Flex Layout
   *******************************/
 
-  [layout][horizontal], [layout][vertical] {
+  .layout.horizontal,
+  .layout.horizontal-reverse,
+  .layout.vertical,
+  .layout.vertical-reverse {
     display: -ms-flexbox;
     display: -webkit-flex;
     display: flex;
   }
 
-  [layout][horizontal][inline], [layout][vertical][inline] {
+  .layout.inline {
     display: -ms-inline-flexbox;
     display: -webkit-inline-flex;
     display: inline-flex;
   }
 
-  [layout][horizontal] {
+  .layout.horizontal {
     -ms-flex-direction: row;
     -webkit-flex-direction: row;
     flex-direction: row;
   }
 
-  [layout][horizontal][reverse] {
+  .layout.horizontal-reverse {
     -ms-flex-direction: row-reverse;
     -webkit-flex-direction: row-reverse;
     flex-direction: row-reverse;
   }
 
-  [layout][vertical] {
+  .layout.vertical {
     -ms-flex-direction: column;
     -webkit-flex-direction: column;
     flex-direction: column;
   }
 
-  [layout][vertical][reverse] {
+  .layout.vertical-reverse {
     -ms-flex-direction: column-reverse;
     -webkit-flex-direction: column-reverse;
     flex-direction: column-reverse;
   }
 
-  [layout][wrap] {
+  .layout.wrap {
     -ms-flex-wrap: wrap;
     -webkit-flex-wrap: wrap;
     flex-wrap: wrap;
   }
 
-  [layout][wrap-reverse] {
+  .layout.wrap-reverse {
     -ms-flex-wrap: wrap-reverse;
     -webkit-flex-wrap: wrap-reverse;
     flex-wrap: wrap-reverse;
   }
 
-  [flex] {
-    -ms-flex: 1;
-    -webkit-flex: 1;
-    flex: 1;
-  }
-
-  [flex][auto] {
+  .flex-auto {
     -ms-flex: 1 1 auto;
     -webkit-flex: 1 1 auto;
     flex: 1 1 auto;
   }
 
-  [flex][none] {
+  .flex-none {
     -ms-flex: none;
     -webkit-flex: none;
     flex: none;
   }
 
-  [flex][one] {
+  .flex,
+  .flex-1 {
     -ms-flex: 1;
     -webkit-flex: 1;
     flex: 1;
   }
 
-  [flex][two] {
+  .flex-2 {
     -ms-flex: 2;
     -webkit-flex: 2;
     flex: 2;
   }
 
-  [flex][three] {
+  .flex-3 {
     -ms-flex: 3;
     -webkit-flex: 3;
     flex: 3;
   }
 
-  [flex][four] {
+  .flex-4 {
     -ms-flex: 4;
     -webkit-flex: 4;
     flex: 4;
   }
 
-  [flex][five] {
+  .flex-5 {
     -ms-flex: 5;
     -webkit-flex: 5;
     flex: 5;
   }
 
-  [flex][six] {
+  .flex-6 {
     -ms-flex: 6;
     -webkit-flex: 6;
     flex: 6;
   }
 
-  [flex][seven] {
+  .flex-7 {
     -ms-flex: 7;
     -webkit-flex: 7;
     flex: 7;
   }
 
-  [flex][eight] {
+  .flex-8 {
     -ms-flex: 8;
     -webkit-flex: 8;
     flex: 8;
   }
 
-  [flex][nine] {
+  .flex-9 {
     -ms-flex: 9;
     -webkit-flex: 9;
     flex: 9;
   }
 
-  [flex][ten] {
+  .flex-10 {
     -ms-flex: 10;
     -webkit-flex: 10;
     flex: 10;
   }
 
-  [flex][eleven] {
+  .flex-11 {
     -ms-flex: 11;
     -webkit-flex: 11;
     flex: 11;
   }
 
-  [flex][twelve] {
+  .flex-12 {
     -ms-flex: 12;
     -webkit-flex: 12;
     flex: 12;
@@ -153,19 +151,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   /* alignment in cross axis */
 
-  [layout][start] {
-    -ms-flex-align: start;
+  .layout.start {
+    -msa-flex-align: start;
     -webkit-align-items: flex-start;
     align-items: flex-start;
   }
 
-  [layout][center], [layout][center-center] {
+  .layout.center,
+  .layout.center-center {
     -ms-flex-align: center;
     -webkit-align-items: center;
     align-items: center;
   }
 
-  [layout][end] {
+  .layout.end {
     -ms-flex-align: end;
     -webkit-align-items: flex-end;
     align-items: flex-end;
@@ -173,31 +172,32 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   /* alignment in main axis */
 
-  [layout][start-justified] {
+  .layout.start-justified {
     -ms-flex-pack: start;
     -webkit-justify-content: flex-start;
     justify-content: flex-start;
   }
 
-  [layout][center-justified], [layout][center-center] {
+  .layout.center-justified,
+  .layout.center-center {
     -ms-flex-pack: center;
     -webkit-justify-content: center;
     justify-content: center;
   }
 
-  [layout][end-justified] {
+  .layout.end-justified {
     -ms-flex-pack: end;
     -webkit-justify-content: flex-end;
     justify-content: flex-end;
   }
 
-  [layout][around-justified] {
+  .layout.around-justified {
     -ms-flex-pack: around;
     -webkit-justify-content: space-around;
     justify-content: space-around;
   }
 
-  [layout][justified] {
+  .layout.justified {
     -ms-flex-pack: justify;
     -webkit-justify-content: space-between;
     justify-content: space-between;
@@ -205,25 +205,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   /* self alignment */
 
-  [self-start] {
+  .self-start {
     -ms-align-self: flex-start;
     -webkit-align-self: flex-start;
     align-self: flex-start;
   }
 
-  [self-center] {
+  .self-center {
     -ms-align-self: center;
     -webkit-align-self: center;
     align-self: center;
   }
 
-  [self-end] {
+  .self-end {
     -ms-align-self: flex-end;
     -webkit-align-self: flex-end;
     align-self: flex-end;
   }
 
-  [self-stretch] {
+  .self-stretch {
     -ms-align-self: stretch;
     -webkit-align-self: stretch;
     align-self: stretch;
@@ -233,24 +233,24 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             Other Layout
   *******************************/
 
-  [block] {
+  .block {
     display: block;
   }
 
   /* ie support for hidden */
-  [hidden] {
+  .hidden {
     display: none !important;
   }
 
-  [invisible] {
+  .invisible {
     visibility: hidden !important;
   }
 
-  [relative] {
+  .relative {
     position: relative;
   }
 
-  [fit] {
+  .fit {
     position: absolute;
     top: 0;
     right: 0;
@@ -258,41 +258,44 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     left: 0;
   }
 
-  body[fullbleed] {
+  body.fullbleed {
     margin: 0;
     height: 100vh;
   }
 
-  [scroll] {
+  .scroll {
     -webkit-overflow-scrolling: touch;
     overflow: auto;
   }
 
   /* fixed position */
 
-  [fixed-top] {
+  .fixed-bottom,
+  .fixed-left,
+  .fixed-right
+  .fixed-top {
     position: fixed;
+  }
+
+  .fixed-top {
     top: 0;
     left: 0;
     right: 0;
   }
 
-  [fixed-right] {
-    position: fixed;
+  .fixed-right {
     top: 0;
     right: 0;
     botttom: 0;
   }
 
-  [fixed-bottom] {
-    position: fixed;
+  .fixed-bottom {
     right: 0;
     bottom: 0;
     left: 0;
   }
 
-  [fixed-left] {
-    position: fixed;
+  .fixed-left {
     top: 0;
     botttom: 0;
     left: 0;
@@ -302,7 +305,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               Other
   *******************************/
 
-  [segment], segment {
+  .segment,
+  segment {
     display: block;
     position: relative;
     -webkit-box-sizing: border-box;

--- a/shadow-layout.html
+++ b/shadow-layout.html
@@ -1,6 +1,6 @@
 <!--
 @license
-Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
 This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
 The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
 The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
@@ -8,309 +8,310 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
 <style>
-/*******************************
-          Flex Layout
-*******************************/
 
-html /deep/ [layout][horizontal], html /deep/ [layout][vertical] {
-  display: -ms-flexbox;
-  display: -webkit-flex;
-  display: flex;
-}
+  /*******************************
+            Flex Layout
+  *******************************/
 
-html /deep/ [layout][horizontal][inline], html /deep/ [layout][vertical][inline] {
-  display: -ms-inline-flexbox;
-  display: -webkit-inline-flex;
-  display: inline-flex;
-}
+  html /deep/ [layout][horizontal], html /deep/ [layout][vertical] {
+    display: -ms-flexbox;
+    display: -webkit-flex;
+    display: flex;
+  }
 
-html /deep/ [layout][horizontal] {
-  -ms-flex-direction: row;
-  -webkit-flex-direction: row;
-  flex-direction: row;
-}
+  html /deep/ [layout][horizontal][inline], html /deep/ [layout][vertical][inline] {
+    display: -ms-inline-flexbox;
+    display: -webkit-inline-flex;
+    display: inline-flex;
+  }
 
-html /deep/ [layout][horizontal][reverse] {
-  -ms-flex-direction: row-reverse;
-  -webkit-flex-direction: row-reverse;
-  flex-direction: row-reverse;
-}
+  html /deep/ [layout][horizontal] {
+    -ms-flex-direction: row;
+    -webkit-flex-direction: row;
+    flex-direction: row;
+  }
 
-html /deep/ [layout][vertical] {
-  -ms-flex-direction: column;
-  -webkit-flex-direction: column;
-  flex-direction: column;
-}
+  html /deep/ [layout][horizontal][reverse] {
+    -ms-flex-direction: row-reverse;
+    -webkit-flex-direction: row-reverse;
+    flex-direction: row-reverse;
+  }
 
-html /deep/ [layout][vertical][reverse] {
-  -ms-flex-direction: column-reverse;
-  -webkit-flex-direction: column-reverse;
-  flex-direction: column-reverse;
-}
+  html /deep/ [layout][vertical] {
+    -ms-flex-direction: column;
+    -webkit-flex-direction: column;
+    flex-direction: column;
+  }
 
-html /deep/ [layout][wrap] {
-  -ms-flex-wrap: wrap;
-  -webkit-flex-wrap: wrap;
-  flex-wrap: wrap;
-}
+  html /deep/ [layout][vertical][reverse] {
+    -ms-flex-direction: column-reverse;
+    -webkit-flex-direction: column-reverse;
+    flex-direction: column-reverse;
+  }
 
-html /deep/ [layout][wrap-reverse] {
-  -ms-flex-wrap: wrap-reverse;
-  -webkit-flex-wrap: wrap-reverse;
-  flex-wrap: wrap-reverse;
-}
+  html /deep/ [layout][wrap] {
+    -ms-flex-wrap: wrap;
+    -webkit-flex-wrap: wrap;
+    flex-wrap: wrap;
+  }
 
-html /deep/ [flex] {
-  -ms-flex: 1;
-  -webkit-flex: 1;
-  flex: 1;
-}
+  html /deep/ [layout][wrap-reverse] {
+    -ms-flex-wrap: wrap-reverse;
+    -webkit-flex-wrap: wrap-reverse;
+    flex-wrap: wrap-reverse;
+  }
 
-html /deep/ [flex][auto] {
-  -ms-flex: 1 1 auto;
-  -webkit-flex: 1 1 auto;
-  flex: 1 1 auto;
-}
+  html /deep/ [flex] {
+    -ms-flex: 1;
+    -webkit-flex: 1;
+    flex: 1;
+  }
 
-html /deep/ [flex][none] {
-  -ms-flex: none;
-  -webkit-flex: none;
-  flex: none;
-}
+  html /deep/ [flex][auto] {
+    -ms-flex: 1 1 auto;
+    -webkit-flex: 1 1 auto;
+    flex: 1 1 auto;
+  }
 
-html /deep/ [flex][one] {
-  -ms-flex: 1;
-  -webkit-flex: 1;
-  flex: 1;
-}
+  html /deep/ [flex][none] {
+    -ms-flex: none;
+    -webkit-flex: none;
+    flex: none;
+  }
 
-html /deep/ [flex][two] {
-  -ms-flex: 2;
-  -webkit-flex: 2;
-  flex: 2;
-}
+  html /deep/ [flex][one] {
+    -ms-flex: 1;
+    -webkit-flex: 1;
+    flex: 1;
+  }
 
-html /deep/ [flex][three] {
-  -ms-flex: 3;
-  -webkit-flex: 3;
-  flex: 3;
-}
+  html /deep/ [flex][two] {
+    -ms-flex: 2;
+    -webkit-flex: 2;
+    flex: 2;
+  }
 
-html /deep/ [flex][four] {
-  -ms-flex: 4;
-  -webkit-flex: 4;
-  flex: 4;
-}
+  html /deep/ [flex][three] {
+    -ms-flex: 3;
+    -webkit-flex: 3;
+    flex: 3;
+  }
 
-html /deep/ [flex][five] {
-  -ms-flex: 5;
-  -webkit-flex: 5;
-  flex: 5;
-}
+  html /deep/ [flex][four] {
+    -ms-flex: 4;
+    -webkit-flex: 4;
+    flex: 4;
+  }
 
-html /deep/ [flex][six] {
-  -ms-flex: 6;
-  -webkit-flex: 6;
-  flex: 6;
-}
+  html /deep/ [flex][five] {
+    -ms-flex: 5;
+    -webkit-flex: 5;
+    flex: 5;
+  }
 
-html /deep/ [flex][seven] {
-  -ms-flex: 7;
-  -webkit-flex: 7;
-  flex: 7;
-}
+  html /deep/ [flex][six] {
+    -ms-flex: 6;
+    -webkit-flex: 6;
+    flex: 6;
+  }
 
-html /deep/ [flex][eight] {
-  -ms-flex: 8;
-  -webkit-flex: 8;
-  flex: 8;
-}
+  html /deep/ [flex][seven] {
+    -ms-flex: 7;
+    -webkit-flex: 7;
+    flex: 7;
+  }
 
-html /deep/ [flex][nine] {
-  -ms-flex: 9;
-  -webkit-flex: 9;
-  flex: 9;
-}
+  html /deep/ [flex][eight] {
+    -ms-flex: 8;
+    -webkit-flex: 8;
+    flex: 8;
+  }
 
-html /deep/ [flex][ten] {
-  -ms-flex: 10;
-  -webkit-flex: 10;
-  flex: 10;
-}
+  html /deep/ [flex][nine] {
+    -ms-flex: 9;
+    -webkit-flex: 9;
+    flex: 9;
+  }
 
-html /deep/ [flex][eleven] {
-  -ms-flex: 11;
-  -webkit-flex: 11;
-  flex: 11;
-}
+  html /deep/ [flex][ten] {
+    -ms-flex: 10;
+    -webkit-flex: 10;
+    flex: 10;
+  }
 
-html /deep/ [flex][twelve] {
-  -ms-flex: 12;
-  -webkit-flex: 12;
-  flex: 12;
-}
+  html /deep/ [flex][eleven] {
+    -ms-flex: 11;
+    -webkit-flex: 11;
+    flex: 11;
+  }
 
-/* alignment in cross axis */
+  html /deep/ [flex][twelve] {
+    -ms-flex: 12;
+    -webkit-flex: 12;
+    flex: 12;
+  }
 
-html /deep/ [layout][start] {
-  -ms-flex-align: start;
-  -webkit-align-items: flex-start;
-  align-items: flex-start;
-}
+  /* alignment in cross axis */
 
-html /deep/ [layout][center], html /deep/ [layout][center-center] {
-  -ms-flex-align: center;
-  -webkit-align-items: center;
-  align-items: center;
-}
+  html /deep/ [layout][start] {
+    -ms-flex-align: start;
+    -webkit-align-items: flex-start;
+    align-items: flex-start;
+  }
 
-html /deep/ [layout][end] {
-  -ms-flex-align: end;
-  -webkit-align-items: flex-end;
-  align-items: flex-end;
-}
+  html /deep/ [layout][center], html /deep/ [layout][center-center] {
+    -ms-flex-align: center;
+    -webkit-align-items: center;
+    align-items: center;
+  }
 
-/* alignment in main axis */
+  html /deep/ [layout][end] {
+    -ms-flex-align: end;
+    -webkit-align-items: flex-end;
+    align-items: flex-end;
+  }
 
-html /deep/ [layout][start-justified] {
-  -ms-flex-pack: start;
-  -webkit-justify-content: flex-start;
-  justify-content: flex-start;
-}
+  /* alignment in main axis */
 
-html /deep/ [layout][center-justified], html /deep/ [layout][center-center] {
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-}
+  html /deep/ [layout][start-justified] {
+    -ms-flex-pack: start;
+    -webkit-justify-content: flex-start;
+    justify-content: flex-start;
+  }
 
-html /deep/ [layout][end-justified] {
-  -ms-flex-pack: end;
-  -webkit-justify-content: flex-end;
-  justify-content: flex-end;
-}
+  html /deep/ [layout][center-justified], html /deep/ [layout][center-center] {
+    -ms-flex-pack: center;
+    -webkit-justify-content: center;
+    justify-content: center;
+  }
 
-html /deep/ [layout][around-justified] {
-  -ms-flex-pack: around;
-  -webkit-justify-content: space-around;
-  justify-content: space-around;
-}
+  html /deep/ [layout][end-justified] {
+    -ms-flex-pack: end;
+    -webkit-justify-content: flex-end;
+    justify-content: flex-end;
+  }
 
-html /deep/ [layout][justified] {
-  -ms-flex-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-}
+  html /deep/ [layout][around-justified] {
+    -ms-flex-pack: around;
+    -webkit-justify-content: space-around;
+    justify-content: space-around;
+  }
 
-/* self alignment */
+  html /deep/ [layout][justified] {
+    -ms-flex-pack: justify;
+    -webkit-justify-content: space-between;
+    justify-content: space-between;
+  }
 
-html /deep/ [self-start] {
-  -ms-align-self: flex-start;
-  -webkit-align-self: flex-start;
-  align-self: flex-start;
-}
+  /* self alignment */
 
-html /deep/ [self-center] {
-  -ms-align-self: center;
-  -webkit-align-self: center;
-  align-self: center;
-}
+  html /deep/ [self-start] {
+    -ms-align-self: flex-start;
+    -webkit-align-self: flex-start;
+    align-self: flex-start;
+  }
 
-html /deep/ [self-end] {
-  -ms-align-self: flex-end;
-  -webkit-align-self: flex-end;
-  align-self: flex-end;
-}
+  html /deep/ [self-center] {
+    -ms-align-self: center;
+    -webkit-align-self: center;
+    align-self: center;
+  }
 
-html /deep/ [self-stretch] {
-  -ms-align-self: stretch;
-  -webkit-align-self: stretch;
-  align-self: stretch;
-}
+  html /deep/ [self-end] {
+    -ms-align-self: flex-end;
+    -webkit-align-self: flex-end;
+    align-self: flex-end;
+  }
 
-/*******************************
-          Other Layout
-*******************************/
+  html /deep/ [self-stretch] {
+    -ms-align-self: stretch;
+    -webkit-align-self: stretch;
+    align-self: stretch;
+  }
 
-html /deep/ [block] {
-  display: block;
-}
+  /*******************************
+            Other Layout
+  *******************************/
 
-/* ie support for hidden */
-html /deep/ [hidden] {
-  display: none !important;
-}
+  html /deep/ [block] {
+    display: block;
+  }
 
-html /deep/ [invisible] {
-  visibility: hidden !important;
-}
+  /* ie support for hidden */
+  html /deep/ [hidden] {
+    display: none !important;
+  }
 
-html /deep/ [relative] {
-  position: relative;
-}
+  html /deep/ [invisible] {
+    visibility: hidden !important;
+  }
 
-html /deep/ [fit] {
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-}
+  html /deep/ [relative] {
+    position: relative;
+  }
 
-body[fullbleed] {
-  margin: 0;
-  height: 100vh;
-}
+  html /deep/ [fit] {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+  }
 
-html /deep/ [scroll] {
-  -webkit-overflow-scrolling: touch;
-  overflow: auto;
-}
+  body[fullbleed] {
+    margin: 0;
+    height: 100vh;
+  }
 
-html /deep/ [fixed-top] {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-}
+  html /deep/ [scroll] {
+    -webkit-overflow-scrolling: touch;
+    overflow: auto;
+  }
 
-html /deep/ [fixed-right] {
-  position: fixed;
-  top: 0;
-  right: 0;
-  botttom: 0;
-}
+  html /deep/ [fixed-top] {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+  }
 
-html /deep/ [fixed-bottom] {
-  position: fixed;
-  right: 0;
-  bottom: 0;
-  left: 0;
-}
+  html /deep/ [fixed-right] {
+    position: fixed;
+    top: 0;
+    right: 0;
+    botttom: 0;
+  }
 
-html /deep/ [fixed-left] {
-  position: fixed;
-  top: 0;
-  botttom: 0;
-  left: 0;
-}
+  html /deep/ [fixed-bottom] {
+    position: fixed;
+    right: 0;
+    bottom: 0;
+    left: 0;
+  }
 
-/*******************************
-            Other
-*******************************/
+  html /deep/ [fixed-left] {
+    position: fixed;
+    top: 0;
+    botttom: 0;
+    left: 0;
+  }
 
-html /deep/ [segment], html /deep/ segment {
-  display: block;
-  position: relative;
-  -webkit-box-sizing: border-box;
-  -ms-box-sizing: border-box;
-  box-sizing: border-box;
-  margin: 1em 0.5em;
-  padding: 1em;
-  background-color: white;
-  -webkit-box-shadow: 0px 0px 0px 1px rgba(0, 0, 0, 0.1);
-  box-shadow: 0px 0px 0px 1px rgba(0, 0, 0, 0.1);
-  border-radius: 5px 5px 5px 5px;
-}
+  /*******************************
+              Other
+  *******************************/
+
+  html /deep/ [segment], html /deep/ segment {
+    display: block;
+    position: relative;
+    -webkit-box-sizing: border-box;
+    -ms-box-sizing: border-box;
+    box-sizing: border-box;
+    margin: 1em 0.5em;
+    padding: 1em;
+    background-color: white;
+    -webkit-box-shadow: 0px 0px 0px 1px rgba(0, 0, 0, 0.1);
+    box-shadow: 0px 0px 0px 1px rgba(0, 0, 0, 0.1);
+    border-radius: 5px 5px 5px 5px;
+  }
 
 </style>

--- a/shadow-layout.html
+++ b/shadow-layout.html
@@ -13,139 +13,137 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             Flex Layout
   *******************************/
 
-  html /deep/ [layout][horizontal], html /deep/ [layout][vertical] {
+  html /deep/ .layout.horizontal,
+  html /deep/ .layout.horizontal-reverse,
+  html /deep/ .layout.vertical,
+  html /deep/ .layout.vertical-reverse {
     display: -ms-flexbox;
     display: -webkit-flex;
     display: flex;
   }
 
-  html /deep/ [layout][horizontal][inline], html /deep/ [layout][vertical][inline] {
+  html /deep/ .layout.inline {
     display: -ms-inline-flexbox;
     display: -webkit-inline-flex;
     display: inline-flex;
   }
 
-  html /deep/ [layout][horizontal] {
+  html /deep/ .layout.horizontal {
     -ms-flex-direction: row;
     -webkit-flex-direction: row;
     flex-direction: row;
   }
 
-  html /deep/ [layout][horizontal][reverse] {
+  html /deep/ .layout.horizontal-reverse {
     -ms-flex-direction: row-reverse;
     -webkit-flex-direction: row-reverse;
     flex-direction: row-reverse;
   }
 
-  html /deep/ [layout][vertical] {
+  html /deep/ .layout.vertical {
     -ms-flex-direction: column;
     -webkit-flex-direction: column;
     flex-direction: column;
   }
 
-  html /deep/ [layout][vertical][reverse] {
+  html /deep/ .layout.vertical-reverse {
     -ms-flex-direction: column-reverse;
     -webkit-flex-direction: column-reverse;
     flex-direction: column-reverse;
   }
 
-  html /deep/ [layout][wrap] {
+  html /deep/ .layout.wrap {
     -ms-flex-wrap: wrap;
     -webkit-flex-wrap: wrap;
     flex-wrap: wrap;
   }
 
-  html /deep/ [layout][wrap-reverse] {
+  html /deep/ .layout.wrap-reverse {
     -ms-flex-wrap: wrap-reverse;
     -webkit-flex-wrap: wrap-reverse;
     flex-wrap: wrap-reverse;
   }
 
-  html /deep/ [flex] {
-    -ms-flex: 1;
-    -webkit-flex: 1;
-    flex: 1;
-  }
-
-  html /deep/ [flex][auto] {
+  html /deep/ .flex-auto {
     -ms-flex: 1 1 auto;
     -webkit-flex: 1 1 auto;
     flex: 1 1 auto;
   }
 
-  html /deep/ [flex][none] {
+  html /deep/ .flex-none {
     -ms-flex: none;
     -webkit-flex: none;
     flex: none;
   }
 
-  html /deep/ [flex][one] {
+  html /deep/ .flex,
+  html /deep/ .flex-1 {
     -ms-flex: 1;
     -webkit-flex: 1;
     flex: 1;
   }
 
-  html /deep/ [flex][two] {
+  html /deep/ .flex-2 {
     -ms-flex: 2;
     -webkit-flex: 2;
     flex: 2;
   }
 
-  html /deep/ [flex][three] {
+  html /deep/ .flex-3 {
     -ms-flex: 3;
     -webkit-flex: 3;
     flex: 3;
   }
 
-  html /deep/ [flex][four] {
+  html /deep/ .flex-4 {
     -ms-flex: 4;
     -webkit-flex: 4;
     flex: 4;
   }
 
-  html /deep/ [flex][five] {
+  html /deep/ .flex-5 {
     -ms-flex: 5;
     -webkit-flex: 5;
     flex: 5;
   }
 
-  html /deep/ [flex][six] {
+  html /deep/ .flex-6 {
     -ms-flex: 6;
     -webkit-flex: 6;
     flex: 6;
   }
 
-  html /deep/ [flex][seven] {
+  html /deep/ .flex-7 {
     -ms-flex: 7;
     -webkit-flex: 7;
     flex: 7;
   }
 
-  html /deep/ [flex][eight] {
+  html /deep/ .flex-8 {
     -ms-flex: 8;
     -webkit-flex: 8;
     flex: 8;
   }
 
-  html /deep/ [flex][nine] {
+  html /deep/ .flex-9 {
     -ms-flex: 9;
     -webkit-flex: 9;
     flex: 9;
   }
 
-  html /deep/ [flex][ten] {
+  html /deep/ .flex-10 {
     -ms-flex: 10;
     -webkit-flex: 10;
     flex: 10;
   }
 
-  html /deep/ [flex][eleven] {
+  html /deep/ .flex-11 {
     -ms-flex: 11;
     -webkit-flex: 11;
     flex: 11;
   }
 
-  html /deep/ [flex][twelve] {
+  html /deep/ .flex-12 {
     -ms-flex: 12;
     -webkit-flex: 12;
     flex: 12;
@@ -153,19 +151,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   /* alignment in cross axis */
 
-  html /deep/ [layout][start] {
+  html /deep/ .layout.start {
     -ms-flex-align: start;
     -webkit-align-items: flex-start;
     align-items: flex-start;
   }
 
-  html /deep/ [layout][center], html /deep/ [layout][center-center] {
+  html /deep/ .layout.center,
+  html /deep/ .layout.center-center {
     -ms-flex-align: center;
     -webkit-align-items: center;
     align-items: center;
   }
 
-  html /deep/ [layout][end] {
+  html /deep/ .layout.end {
     -ms-flex-align: end;
     -webkit-align-items: flex-end;
     align-items: flex-end;
@@ -173,31 +172,32 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   /* alignment in main axis */
 
-  html /deep/ [layout][start-justified] {
+  html /deep/ .layout.start-justified {
     -ms-flex-pack: start;
     -webkit-justify-content: flex-start;
     justify-content: flex-start;
   }
 
-  html /deep/ [layout][center-justified], html /deep/ [layout][center-center] {
+  html /deep/ .layout.center-justified,
+  html /deep/ .layout.center-center {
     -ms-flex-pack: center;
     -webkit-justify-content: center;
     justify-content: center;
   }
 
-  html /deep/ [layout][end-justified] {
+  html /deep/ .layout.end-justified {
     -ms-flex-pack: end;
     -webkit-justify-content: flex-end;
     justify-content: flex-end;
   }
 
-  html /deep/ [layout][around-justified] {
+  html /deep/ .layout.around-justified {
     -ms-flex-pack: around;
     -webkit-justify-content: space-around;
     justify-content: space-around;
   }
 
-  html /deep/ [layout][justified] {
+  html /deep/ .layout.justified {
     -ms-flex-pack: justify;
     -webkit-justify-content: space-between;
     justify-content: space-between;
@@ -205,25 +205,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   /* self alignment */
 
-  html /deep/ [self-start] {
+  html /deep/ .self-start {
     -ms-align-self: flex-start;
     -webkit-align-self: flex-start;
     align-self: flex-start;
   }
 
-  html /deep/ [self-center] {
+  html /deep/ .self-center {
     -ms-align-self: center;
     -webkit-align-self: center;
     align-self: center;
   }
 
-  html /deep/ [self-end] {
+  html /deep/ .self-end {
     -ms-align-self: flex-end;
     -webkit-align-self: flex-end;
     align-self: flex-end;
   }
 
-  html /deep/ [self-stretch] {
+  html /deep/ .self-stretch {
     -ms-align-self: stretch;
     -webkit-align-self: stretch;
     align-self: stretch;
@@ -233,24 +233,24 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             Other Layout
   *******************************/
 
-  html /deep/ [block] {
+  html /deep/ .block {
     display: block;
   }
 
   /* ie support for hidden */
-  html /deep/ [hidden] {
+  html /deep/ .hidden {
     display: none !important;
   }
 
-  html /deep/ [invisible] {
+  html /deep/ .invisible {
     visibility: hidden !important;
   }
 
-  html /deep/ [relative] {
+  html /deep/ .relative {
     position: relative;
   }
 
-  html /deep/ [fit] {
+  html /deep/ .fit {
     position: absolute;
     top: 0;
     right: 0;
@@ -258,39 +258,42 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     left: 0;
   }
 
-  body[fullbleed] {
+  body.fullbleed {
     margin: 0;
     height: 100vh;
   }
 
-  html /deep/ [scroll] {
+  html /deep/ .scroll {
     -webkit-overflow-scrolling: touch;
     overflow: auto;
   }
 
-  html /deep/ [fixed-top] {
+  .fixed-bottom,
+  .fixed-left,
+  .fixed-right,
+  .fixed-top {
     position: fixed;
+  }
+
+  html /deep/ .fixed-top {
     top: 0;
     left: 0;
     right: 0;
   }
 
-  html /deep/ [fixed-right] {
-    position: fixed;
+  html /deep/ .fixed-right {
     top: 0;
     right: 0;
     botttom: 0;
   }
 
-  html /deep/ [fixed-bottom] {
-    position: fixed;
+  html /deep/ .fixed-bottom {
     right: 0;
     bottom: 0;
     left: 0;
   }
 
-  html /deep/ [fixed-left] {
-    position: fixed;
+  html /deep/ .fixed-left {
     top: 0;
     botttom: 0;
     left: 0;
@@ -300,7 +303,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               Other
   *******************************/
 
-  html /deep/ [segment], html /deep/ segment {
+  html /deep/ .segment,
+  html /deep/ segment {
     display: block;
     position: relative;
     -webkit-box-sizing: border-box;


### PR DESCRIPTION
- `[vertical][reverse]` and `[horizontal][reverse]` become
  `.vertical-reverse` and `.horizontal-reverse`, respectively, to match
  `[wrap-reverse]`/`.wrap-reverse`
- `[flex][one]`, et al become `.flex-1`, `.flex-2`, etc. to shorten and
  move away from generic attributes/classes like "one" and "two"

Example:

``` html
<div layout horizontal reverse>
  <div flex one self-end></div>
  <div flex four></div>
</div>
```

becomes

``` html
<div class="layout horizontal-reverse">
  <div class="flex-1 self-end"></div>
  <div class="flex-4"></div>
</div>
```
