### PR TITLE
Remove styles used only in demos

### DIFF
--- a/layout.html
+++ b/layout.html
@@ -297,22 +297,4 @@ body[fullbleed] {
   left: 0;
 }
 
-/*******************************
-            Other
-*******************************/
-
-[segment], segment {
-  display: block;
-  position: relative;
-  -webkit-box-sizing: border-box;
-  -ms-box-sizing: border-box;
-  box-sizing: border-box;
-  margin: 1em 0.5em;
-  padding: 1em;
-  background-color: white;
-  -webkit-box-shadow: 0px 0px 0px 1px rgba(0, 0, 0, 0.1);
-  box-shadow: 0px 0px 0px 1px rgba(0, 0, 0, 0.1);
-  border-radius: 5px 5px 5px 5px;
-}
-
 </style>

--- a/shadow-layout.html
+++ b/shadow-layout.html
@@ -295,22 +295,4 @@ html /deep/ [fixed-left] {
   left: 0;
 }
 
-/*******************************
-            Other
-*******************************/
-
-html /deep/ [segment], html /deep/ segment {
-  display: block;
-  position: relative;
-  -webkit-box-sizing: border-box;
-  -ms-box-sizing: border-box;
-  box-sizing: border-box;
-  margin: 1em 0.5em;
-  padding: 1em;
-  background-color: white;
-  -webkit-box-shadow: 0px 0px 0px 1px rgba(0, 0, 0, 0.1);
-  box-shadow: 0px 0px 0px 1px rgba(0, 0, 0, 0.1);
-  border-radius: 5px 5px 5px 5px;
-}
-
 </style>


### PR DESCRIPTION
The `segment` element and styles were used only in the core-icon demo.
The styles were copied to the demo in
https://github.com/Polymer/core-icon/pull/36 and are no longer needed in
this core repo.
