### PR TITLE
added missing comma in fixed position css block

### DIFF
--- a/layout.html
+++ b/layout.html
@@ -272,7 +272,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   .fixed-bottom,
   .fixed-left,
-  .fixed-right
+  .fixed-right,
   .fixed-top {
     position: fixed;
   }


### PR DESCRIPTION
Hey,

While looking through the changes from using layout attributes to CSS classes, I noticed that there was a comma missing in the "fixed position" block of CSS. 

Nothing major but thought I'd call it out and provide a quick fix. :)
