### PR TITLE
includes shadow-layout.html for Shadow DOM

### DIFF
--- a/layout.html
+++ b/layout.html
@@ -7,6 +7,9 @@ The complete set of contributors may be found at http://polymer.github.io/CONTRI
 Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
+
+<link rel="import" href="shadow-layout.html">
+
 <style>
 
   /*******************************


### PR DESCRIPTION
includes shadow-layout.html so both Shadow DOM and Shady DOM will work by just importing layout.html.  @sorvell will look at ways to improve this.
