### PR TITLE
Revert .hidden to [hidden] HTML5 attribute

### DIFF
--- a/layout.html
+++ b/layout.html
@@ -240,8 +240,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     display: block;
   }
 
-  /* ie support for hidden */
-  .hidden {
+  /* IE 10 support for HTML5 hidden attr */
+  [hidden] {
     display: none !important;
   }
 

--- a/shadow-layout.html
+++ b/shadow-layout.html
@@ -237,8 +237,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     display: block;
   }
 
-  /* ie support for hidden */
-  html /deep/ .hidden {
+  /* IE 10 support for HTML5 hidden attr */
+  html /deep/ [hidden] {
     display: none !important;
   }
 


### PR DESCRIPTION
`[hidden]` is an attribute in HTML5, and this block was intended to add
support for it in IE <11. Remove the `.hidden` class since hiding els
is natively supported in HTML5 via the attribute version.

See http://www.w3.org/TR/html5/editing.html#the-hidden-attribute
